### PR TITLE
Fix broken link and wrong package address

### DIFF
--- a/content/home/getting-started.md
+++ b/content/home/getting-started.md
@@ -36,7 +36,7 @@ func main() {
 Cobra provides its own program that will create your application and add any
 commands you want. It's the easiest way to incorporate Cobra into your application.
 
-[Here](https://github.com/spf13/cobra/blob/master/cobra/README.md) you can find more information about it.
+[Here](https://github.com/spf13/cobra-cli/blob/main/README.md) you can find more information about it.
 
 ## Using the Cobra Library
 

--- a/content/home/install.md
+++ b/content/home/install.md
@@ -3,11 +3,10 @@ title: "Install"
 weight: 20
 ---
 
-Using Cobra is easy. First, use `go get` to install the latest version
-of the library. This command will install the `cobra` generator executable
-along with the library and its dependencies:
+Using Cobra is easy. Use `go get` to install the latest version
+of the library and its dependencies:
 
-    go get -u github.com/spf13/cobra/cobra
+    go get -u github.com/spf13/cobra
 
 Next, include Cobra in your application:
 


### PR DESCRIPTION
#### Why
* There is a wrong package address in the `install` section
* Wrong cobra generator document link in the `Using the Cobra Generator` section
* Fix #4 

#### Changes
* Update cobra package address
* Update cobra generator document link