### PR TITLE
Update link to cobra-cli documentation

### DIFF
--- a/content/home/getting-started.md
+++ b/content/home/getting-started.md
@@ -36,7 +36,7 @@ func main() {
 Cobra provides its own program that will create your application and add any
 commands you want. It's the easiest way to incorporate Cobra into your application.
 
-[Here](https://github.com/spf13/cobra/blob/master/cobra/README.md) you can find more information about it.
+[Here](https://github.com/spf13/cobra-cli) you can find more information about it.
 
 ## Using the Cobra Library
 


### PR DESCRIPTION
Took me a couple mins after finding that dead link to find the cobra-cli repo and documentation.

The install section might need updated as well, since I think it states that the generator tool is installed with the `go get` command, but I don't think that's true anymore.