### PR TITLE
Fix the command to install cobra

### DIFF
--- a/content/home/install.md
+++ b/content/home/install.md
@@ -7,7 +7,7 @@ Using Cobra is easy. First, use `go get` to install the latest version
 of the library. This command will install the `cobra` generator executable
 along with the library and its dependencies:
 
-    go get -u github.com/spf13/cobra/cobra
+    go get -u github.com/spf13/cobra@latest
 
 Next, include Cobra in your application:
 


### PR DESCRIPTION
## Description

The previous link wasn't working

```bash
[computer ~/Git/my-go-lang-project]: go get -u github.com/spf13/cobra/cobra
go: downloading github.com/spf13/cobra v1.6.1
go: module github.com/spf13/cobra@upgrade found (v1.6.1), but does not contain package github.com/spf13/cobra/cobra
```