### PR TITLE
Fix LICENSE link

### DIFF
--- a/content/home/license.md
+++ b/content/home/license.md
@@ -3,4 +3,4 @@ title: "License"
 weight: 100
 ---
 
-Cobra is released under the Apache 2.0 license. See [LICENSE.txt](https://github.com/spf13/cobra/blob/master/LICENSE.txt)
+Cobra is released under the Apache 2.0 license. See [LICENSE.txt](https://github.com/spf13/cobra/blob/main/LICENSE.txt)


### PR DESCRIPTION
Branch master of https://github.com/spf13/cobra was renamed to main.