### PR TITLE
Fix "go get" command for installation

### DIFF
--- a/content/home/install.md
+++ b/content/home/install.md
@@ -7,7 +7,7 @@ Using Cobra is easy. First, use `go get` to install the latest version
 of the library. This command will install the `cobra` generator executable
 along with the library and its dependencies:
 
-    go get -u github.com/spf13/cobra/cobra
+    go get -u github.com/spf13/cobra
 
 Next, include Cobra in your application:
 


### PR DESCRIPTION
With updates to the go CLI, the required target has changed. This commit modifies the command to be the one that works now.

Fixes: https://github.com/spf13/cobra/issues/2057