### PR TITLE
Fixes #30 - edit url of cobra-cli markdown

### DIFF
--- a/content/home/getting-started.md
+++ b/content/home/getting-started.md
@@ -36,7 +36,7 @@ func main() {
 Cobra provides its own program that will create your application and add any
 commands you want. It's the easiest way to incorporate Cobra into your application.
 
-[Here](https://github.com/spf13/cobra/blob/master/cobra/README.md) you can find more information about it.
+[Here](https://github.com/spf13/cobra-cli/blob/main/README.md) you can find more information about it.
 
 ## Using the Cobra Library
 


### PR DESCRIPTION
Fixes #30 
Hello, this is a fix about Cobra CLI Markdown link.
I don't sure if it is intended, but the link seems to be wrong.
Or, do you have any plans to add a file to previously written path?